### PR TITLE
Use correct constant name for VAT type

### DIFF
--- a/src/Configurations/Accounts.php
+++ b/src/Configurations/Accounts.php
@@ -6,7 +6,7 @@ class Accounts
 {
     const SALES_HIGH_VAT = '3000';
     const SALES_MEDIUM_VAT = '3030';
-    const SALES_EX_VAT = '3100';
+    const SALES_EXEMPT_VAT = '3100';
     const SHIPPING = '6940';
     const SALES_COSTS = '7300';
     const GIFTCARDS = '2900';


### PR DESCRIPTION
Making a fix for webshop after this has been merged and new version has been tagged