### PR TITLE
Add unitNetAmount as supported type

### DIFF
--- a/src/Resources/Orderitem.php
+++ b/src/Resources/Orderitem.php
@@ -14,7 +14,8 @@ class Orderitem extends DataObject
             'account' => 'string',
             'vatType' => 'string',
             'netPriceInCurrency' => 'int',
-            'vatInCurrency' => 'int'
+            'vatInCurrency' => 'int',
+            'unitNetAmount' => 'int',
         ];
     }
 


### PR DESCRIPTION
Fixes a bug in webshop after [#5644](https://github.com/SincosSoftware/webshop/pull/5644) was merged.

`The class 'FikenSDK\Resources\Orderitem' does not support the property unitNetAmount.`